### PR TITLE
fix: can not install linglong app from store.linglong.dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,6 +42,7 @@ Depends: desktop-file-utils,
          linglong-box | crun,
          ostree,
          shared-mime-info,
+         linglong-installer,
          ${misc:Depends},
          ${shlibs:Depends}
 Replaces: linglong-dbus-proxy


### PR DESCRIPTION
install linglong app should install linglong-installer, add it to install depends

Log: