### PR TITLE
fix: linglong-session-helper can not start normal

### DIFF
--- a/misc/lib/systemd/user/linglong-session-helper.service
+++ b/misc/lib/systemd/user/linglong-session-helper.service
@@ -11,4 +11,4 @@ ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/linglong/ll-session-helper
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-users.target


### PR DESCRIPTION
WantedBy should be multi-users in systemd service

Log: